### PR TITLE
fix(page-scroll): updated ng2-page-scroll and fixed apply buttons on careers and projects pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ deploy:
     repo: VS-work/VS-work.github.io
     target-branch: master
     on:
-      branch: master
+      branch: development
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
@@ -24,4 +24,4 @@ deploy:
     target-branch: master
     repo: valor-software/valor-software.github.io
     on:
-      branch: development
+      branch: master

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@angular/platform-browser-dynamic": "5.2.8",
     "@angular/router": "5.2.8",
     "core-js": "2.5.1",
-    "ng2-page-scroll": "3.2.3",
+    "ng2-page-scroll": "4.0.0-beta.12",
     "ngx-bootstrap": "2.0.3",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.5.7",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -65,7 +65,7 @@ const routing = RouterModule.forRoot(routes);
     FormsModule,
     HttpModule,
     routing,
-    Ng2PageScrollModule.forRoot(),
+    Ng2PageScrollModule,
     CarouselModule.forRoot()
   ],
 

--- a/src/components/project/project.html
+++ b/src/components/project/project.html
@@ -32,7 +32,7 @@
         </div>
       </div>
       <div class="col-lg-1 col-md-1">
-        <button pageScroll href="#startForm" class="btn btn_scroll btn_small project__btn">Start</button>
+        <button pageScroll pageScrollDuration="1000" pageScrollTarget="#startForm" class="btn btn_scroll btn_small project__btn">Start</button>
       </div>
     </div>
 

--- a/src/components/vacancy/vacancy.component.ts
+++ b/src/components/vacancy/vacancy.component.ts
@@ -47,20 +47,4 @@ export class VacancyComponent implements OnInit {
       this._titleService.setTitle(`Vacancy: ${this.vacancy.name}`);
     });
   }
-
-  public scrollTo(e: MouseEvent): void {
-    const inc = 20;
-    const duration = 1000;
-    e.preventDefault();
-    this.animateScroll('applyForm', inc, duration);
-  }
-
-  public animateScroll(id: string, inc: number, duration: number): any {
-    const elem = document.getElementById(id);
-    const startScroll = document.body.scrollTop || document.documentElement.scrollTop;
-    const endScroll = elem.offsetTop;
-    const step = (endScroll - startScroll) / duration * inc;
-
-    window.requestAnimationFrame(VacancyComponent.goToScroll(step, duration, inc));
-  }
 }

--- a/src/components/vacancy/vacancy.html
+++ b/src/components/vacancy/vacancy.html
@@ -16,7 +16,7 @@
         <p>{{ vacancy.description }}</p>
       </div>
       <div class="col-lg-1 col-md-1">
-        <button pageScroll (click)="scrollTo($event)" class="btn btn_scroll btn_small project__btn">Apply</button>
+        <button pageScroll pageScrollDuration="1000" pageScrollTarget="#applyForm" class="btn btn_scroll btn_small project__btn">Apply</button>
       </div>
     </div>
 


### PR DESCRIPTION
- Updated ng2-page-scroll package
- Changed `href` attribute to `pageScrollTarget` on `Apply` buttons
- Removed `forRoot` from `Ng2PageScrollModule`
- Switched gh-pages deployment paths in travis 